### PR TITLE
프론트, 백엔드, 데이터 서버 연결

### DIFF
--- a/src/main/java/com/hangangFlow/hangangFlow/WebConfig.java
+++ b/src/main/java/com/hangangFlow/hangangFlow/WebConfig.java
@@ -9,7 +9,7 @@ public class WebConfig extends WebMvcConfigurerAdapter {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:4000")
+                .allowedOrigins("http://localhost:4000", "http://localhost:3000", "http://localhost:8000")
                 .allowedHeaders("*")
                 .allowCredentials(true);
     }

--- a/src/main/java/com/hangangFlow/hangangFlow/controller/ParkController.java
+++ b/src/main/java/com/hangangFlow/hangangFlow/controller/ParkController.java
@@ -35,8 +35,58 @@ public class ParkController {
         return parkListVO;
     }
 
+    // flask 통해서 공원 리스트
+    // keywords에 flask의 JSON 데이터가 들어감
+//    @GetMapping("/searchpark")
+//    public List<ParkVO> searchPark(@RequestBody Map<String, List<UUID>> requestBody) {
+//        List<UUID> parkUuidList = requestBody.get("park_uuid");
+//
+//        // MariaDB에서 데이터 찾기
+//        List<Parks> result = parkService.searchParkList(parkUuidList);
+//
+//        // ParkVO로 변환하여 반환
+//        return result.stream().map(ParkVO::new).collect(Collectors.toList());
+//    }
+
+//    @GetMapping("/searchPark")
+//    public ResponseEntity<List<ParkVO> searchPark(@RequestParam String params) {
+//        List<String> keywordList = ArrayList.
+//    }
+
+//    private final RestTemplate restTemplate;
+//    private final ParkService parkService; // 추가: ParkService 주입
+
+//    @GetMapping("")
+//    public ResponseEntity<List<Parks>> searchPark(@RequestParam List<String> keyword) {
+//        String flaskApiUrl = "http://localhost:8000/data?keyword=" + String.join(",", keyword);
+//        System.out.println("checkLog--- flaskApiUrl" + flaskApiUrl);
+//        try {
+//            ResponseEntity<Map<String, List<String>>> flaskResponse = restTemplate.exchange(
+//                    flaskApiUrl,
+//                    HttpMethod.GET,
+//                    null,
+//                    new ParameterizedTypeReference<Map<String, List<String>>>() {}
+//            );
+//
+//            List<String> uuidList = flaskResponse.getBody().get("park_uuid");
+//            System.out.println("checkLog--- uuidList" + uuidList);
+//
+//            List<UUID> parkUuidList = uuidList.stream()
+//                    .map(UUID::fromString)
+//                    .collect(Collectors.toList());
+//            System.out.println("checkLog--- parkUuidList" + uuidList);
+//
+//            List<Parks> parkList = parkService.searchParkList(parkUuidList); // 수정: ParkService의 메서드 활용
+//            System.out.println("checkLog--- parkUuidList" + parkList);
+//            return ResponseEntity.ok(parkList);
+//        } catch (Exception e) {
+//            e.printStackTrace();
+//            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+//        }
+//    }
+
     @GetMapping("")
-    public ResponseEntity<List<Parks>> searchPark(@RequestParam List<String> keyword) {
+    public ResponseEntity<List<ParkVO>> searchPark(@RequestParam List<String> keyword) {
         String flaskApiUrl = "http://localhost:8000/data?keyword=" + String.join(",", keyword);
         System.out.println("checkLog--- flaskApiUrl" + flaskApiUrl);
         try {
@@ -48,27 +98,23 @@ public class ParkController {
             );
 
             List<String> uuidList = flaskResponse.getBody().get("park_uuid");
+            System.out.println("checkLog--- uuidList" + uuidList);
 
             List<UUID> parkUuidList = uuidList.stream()
                     .map(UUID::fromString)
                     .collect(Collectors.toList());
+            System.out.println("checkLog--- parkUuidList" + parkUuidList);
 
-            List<Parks> parkList = parkService.searchParkList(parkUuidList);
+            List<Parks> parkList = parkService.searchParkList(parkUuidList); // 수정: 공원 정보 가져오기
 
-            return ResponseEntity.ok(parkList);
+            List<ParkVO> parkVOList = parkList.stream().map(ParkVO::new).collect(Collectors.toList());
+
+            return ResponseEntity.ok(parkVOList);
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
 
-
-//    private List<UUID> convertUuidStringsToUuids(List<String> uuidStrings) {
-//        List<UUID> uuids = new ArrayList<>();
-//        for (String uuidString : uuidStrings) {
-//            uuids.add(UUID.fromString(uuidString));
-//        }
-//        return uuids;
-//    }
 
 }

--- a/src/main/java/com/hangangFlow/hangangFlow/controller/ParkController.java
+++ b/src/main/java/com/hangangFlow/hangangFlow/controller/ParkController.java
@@ -5,6 +5,9 @@ import com.hangangFlow.hangangFlow.service.ParkService;
 import com.hangangFlow.hangangFlow.vo.ParkVO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -24,7 +27,7 @@ public class ParkController {
 
     @Autowired
     private final RestTemplate restTemplate;
-    @GetMapping("/parklist")
+    @GetMapping("/parkList")
     public List<ParkVO> listPark() {
         List<Parks> parkList = parkService.viewParkList();
         List<ParkVO> parkListVO = parkList.stream().map(ParkVO::new).collect(Collectors.toList());
@@ -51,28 +54,31 @@ public class ParkController {
 //    }
 
     // 공원 상세보기
-    @GetMapping("/{parkUuid}")
-    public ResponseEntity<List<ParkVO>> searchPark(@RequestParam String keywords) {
+    @GetMapping("")
+    public ResponseEntity<List<ParkVO>> searchPark(@RequestParam String keyword) {
+        String flaskApiUrl = "http://localhost:8000/data?keyword=" + keyword;
+        ResponseEntity<Map<String, List<String>>> flaskResponse = restTemplate.exchange(
+                flaskApiUrl,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<Map<String, List<String>>>() {}
+        );
 
-        String flaskApiUrl = "http://flask-data-server-url/flask-endpoint?keywords=" + keywords;
-        ResponseEntity<String[]> flaskResponse = restTemplate.getForEntity(flaskApiUrl, String[].class);
-        List<UUID> parkUuids = convertUuidStringsToUuids(Arrays.asList(Objects.requireNonNull(flaskResponse.getBody())));
+        List<String> uuidList = flaskResponse.getBody().get("park_uuid");
 
-        List<Parks> parkList = parkService.searchParkList(parkUuids);
-
-        List<ParkVO> parkVOList = parkList.stream()
-                .map(ParkVO::new)
-                .collect(Collectors.toList());
-
-        return ResponseEntity.ok(parkVOList);
-    }
-
-    private List<UUID> convertUuidStringsToUuids(List<String> uuidStrings) {
-        List<UUID> uuids = new ArrayList<>();
-        for (String uuidString : uuidStrings) {
-            uuids.add(UUID.fromString(uuidString));
+        List<ParkVO> parkList = new ArrayList<>();
+        try {
+            for (String uuid : uuidList) {
+                UUID parkUuid = UUID.fromString(uuid);
+                ParkVO parkVO = parkService.findPark(parkUuid); // Service에서 ParkVO를 생성하는 메서드 활용
+                parkList.add(parkVO);
+            }
+            return ResponseEntity.ok(parkList);
+        } catch (Exception e) {
+            // 에러 처리
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
-        return uuids;
     }
+
 
 }

--- a/src/main/java/com/hangangFlow/hangangFlow/controller/ParkController.java
+++ b/src/main/java/com/hangangFlow/hangangFlow/controller/ParkController.java
@@ -35,50 +35,40 @@ public class ParkController {
         return parkListVO;
     }
 
-    // flask 통해서 공원 리스트
-    // keywords에 flask의 JSON 데이터가 들어감
-//    @GetMapping("/searchpark")
-//    public List<ParkVO> searchPark(@RequestBody Map<String, List<UUID>> requestBody) {
-//        List<UUID> parkUuidList = requestBody.get("park_uuid");
-//
-//        // MariaDB에서 데이터 찾기
-//        List<Parks> result = parkService.searchParkList(parkUuidList);
-//
-//        // ParkVO로 변환하여 반환
-//        return result.stream().map(ParkVO::new).collect(Collectors.toList());
-//    }
-
-//    @GetMapping("/searchPark")
-//    public ResponseEntity<List<ParkVO> searchPark(@RequestParam String params) {
-//        List<String> keywordList = ArrayList.
-//    }
-
-    // 공원 상세보기
     @GetMapping("")
-    public ResponseEntity<List<ParkVO>> searchPark(@RequestParam String keyword) {
-        String flaskApiUrl = "http://localhost:8000/data?keyword=" + keyword;
-        ResponseEntity<Map<String, List<String>>> flaskResponse = restTemplate.exchange(
-                flaskApiUrl,
-                HttpMethod.GET,
-                null,
-                new ParameterizedTypeReference<Map<String, List<String>>>() {}
-        );
-
-        List<String> uuidList = flaskResponse.getBody().get("park_uuid");
-
-        List<ParkVO> parkList = new ArrayList<>();
+    public ResponseEntity<List<Parks>> searchPark(@RequestParam List<String> keyword) {
+        String flaskApiUrl = "http://localhost:8000/data?keyword=" + String.join(",", keyword);
+        System.out.println("checkLog--- flaskApiUrl" + flaskApiUrl);
         try {
-            for (String uuid : uuidList) {
-                UUID parkUuid = UUID.fromString(uuid);
-                ParkVO parkVO = parkService.findPark(parkUuid); // Service에서 ParkVO를 생성하는 메서드 활용
-                parkList.add(parkVO);
-            }
+            ResponseEntity<Map<String, List<String>>> flaskResponse = restTemplate.exchange(
+                    flaskApiUrl,
+                    HttpMethod.GET,
+                    null,
+                    new ParameterizedTypeReference<Map<String, List<String>>>() {}
+            );
+
+            List<String> uuidList = flaskResponse.getBody().get("park_uuid");
+
+            List<UUID> parkUuidList = uuidList.stream()
+                    .map(UUID::fromString)
+                    .collect(Collectors.toList());
+
+            List<Parks> parkList = parkService.searchParkList(parkUuidList);
+
             return ResponseEntity.ok(parkList);
         } catch (Exception e) {
-            // 에러 처리
+            e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
 
+
+//    private List<UUID> convertUuidStringsToUuids(List<String> uuidStrings) {
+//        List<UUID> uuids = new ArrayList<>();
+//        for (String uuidString : uuidStrings) {
+//            uuids.add(UUID.fromString(uuidString));
+//        }
+//        return uuids;
+//    }
 
 }

--- a/src/main/java/com/hangangFlow/hangangFlow/domain/park/ParkRepository.java
+++ b/src/main/java/com/hangangFlow/hangangFlow/domain/park/ParkRepository.java
@@ -11,4 +11,6 @@ public interface ParkRepository extends JpaRepository<Parks, UUID> {
 
     Parks findByParkUuid(UUID parkUuid);
 
+
+
 }

--- a/src/main/java/com/hangangFlow/hangangFlow/service/ParkServiceImpl.java
+++ b/src/main/java/com/hangangFlow/hangangFlow/service/ParkServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -34,8 +35,16 @@ public class ParkServiceImpl implements ParkService {
 
     @Override
     public List<Parks> searchParkList(List<UUID> parkUuids) {
+        List<Parks> parkList = new ArrayList<>();
 
-        return parkRepository.findAllById(parkUuids);
+        for (UUID parkUuid : parkUuids) {
+            Parks park = parkRepository.findByParkUuid(parkUuid);
+            if (park != null) {
+                parkList.add(park);
+            }
+        }
+
+        return parkList;
     }
 
     @Override


### PR DESCRIPTION
## 📌 Related Issue

- Closed #

## 🧾 Describe your changes

## 📚 Etc
**유저 선택 키워드 기반 한강공원 추천 알고리즘 구현 방식**
1. 프론트엔드가 /api/parkInfo/searchpark 엔드포인트로 GET 요청을 보내고, 선택한 키워드를 쿼리 스트링으로 전달

2. 백엔드 서버가 해당 요청을 받아 Flask 서버로 GET 요청을 보낸다. 이때 Flask 서버의 /data 엔드포인트로 선택한 키워드를 쿼리 스트링으로 전달한다.

3. Flask 서버가 받은 키워드에 따라 공원 정보를 생성하고, 데이터베이스에서 UUID를 가져와 JSON 형태로 응답한다.

4. 백엔드 서버가 Flask 서버의 응답을 받아서 해당 공원 정보를 JSON 데이터로 가공한 뒤, 프론트엔드로 응답한다.

5. 프론트엔드가 받은 백엔드의 응답을 처리하고 화면에 표시한다.


